### PR TITLE
Initialize Digi Task skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Digi Task Monorepo
+
+This repository contains the backend and mobile clients for **Digi Task**.
+Both projects are intentionally lightweight to serve as a starting point.
+
+- `backend/` – Laravel 10 skeleton
+- `mobile/` – Flutter 3.3 application
+
+Follow the respective README files in each directory for setup instructions.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+APP_NAME=DigiTask
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+DB_CONNECTION=sqlite
+DB_DATABASE=database/database.sqlite

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,16 @@
+# Digi Task Backend
+
+This is a lightweight Laravel skeleton for the Digi Task application.
+
+## Requirements
+- PHP 8.3+
+- Composer
+
+## Setup
+1. `composer install`
+2. Copy `.env.example` to `.env` and configure your database
+3. `php artisan migrate`
+4. `php artisan serve`
+
+## Testing
+Run `composer test` to execute the PHPUnit test suite.

--- a/backend/app/Http/Controllers/TaskController.php
+++ b/backend/app/Http/Controllers/TaskController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Task;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class TaskController extends Controller
+{
+    public function index(): Response
+    {
+        return response(Task::all());
+    }
+
+    public function store(Request $request): Response
+    {
+        $task = Task::create($request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'due_date' => 'nullable|date',
+        ]));
+
+        return response($task, 201);
+    }
+
+    public function show(Task $task): Response
+    {
+        return response($task);
+    }
+
+    public function update(Request $request, Task $task): Response
+    {
+        $task->update($request->validate([
+            'title' => 'sometimes|required|string|max:255',
+            'description' => 'nullable|string',
+            'due_date' => 'nullable|date',
+            'completed' => 'boolean',
+        ]));
+
+        return response($task);
+    }
+
+    public function destroy(Task $task): Response
+    {
+        $task->delete();
+
+        return response(null, 204);
+    }
+}

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'due_date',
+        'completed'
+    ];
+
+    protected $casts = [
+        'completed' => 'boolean',
+        'due_date' => 'datetime',
+    ];
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "digi-task/backend",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "laravel/framework": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/backend/database/migrations/2024_01_01_100000_create_tasks_table.php
+++ b/backend/database/migrations/2024_01_01_100000_create_tasks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->timestamp('due_date')->nullable();
+            $table->boolean('completed')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TaskController;
+
+Route::apiResource('tasks', TaskController::class);

--- a/backend/tests/Feature/TaskTest.php
+++ b/backend/tests/Feature/TaskTest.php
@@ -1,0 +1,6 @@
+<?php
+
+test('tasks endpoint returns empty array', function () {
+    $response = $this->getJson('/api/tasks');
+    $response->assertStatus(200)->assertExactJson([]);
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,8 @@
+# Digi Task Mobile
+
+Flutter application for Digi Task built with the latest stable Flutter SDK.
+
+## Getting Started
+1. Install Flutter 3.3+ from [flutter.dev](https://flutter.dev)
+2. Run `flutter pub get`
+3. Launch with `flutter run`

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const DigiTaskApp());
+}
+
+class DigiTaskApp extends StatelessWidget {
+  const DigiTaskApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Digi Task',
+      theme: ThemeData(
+        primarySwatch: Colors.indigo,
+      ),
+      home: const TaskListScreen(),
+    );
+  }
+}
+
+class TaskListScreen extends StatelessWidget {
+  const TaskListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tasks'),
+      ),
+      body: const Center(
+        child: Text('No tasks yet'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/models/task.dart
+++ b/mobile/lib/models/task.dart
@@ -1,0 +1,32 @@
+class Task {
+  final int id;
+  final String title;
+  final String? description;
+  final DateTime? dueDate;
+  final bool completed;
+
+  Task({
+    required this.id,
+    required this.title,
+    this.description,
+    this.dueDate,
+    this.completed = false,
+  });
+
+  factory Task.fromJson(Map<String, dynamic> json) => Task(
+        id: json['id'] as int,
+        title: json['title'] as String,
+        description: json['description'] as String?,
+        dueDate:
+            json['due_date'] != null ? DateTime.parse(json['due_date']) : null,
+        completed: json['completed'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'due_date': dueDate?.toIso8601String(),
+        'completed': completed,
+      };
+}

--- a/mobile/lib/services/task_service.dart
+++ b/mobile/lib/services/task_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import '../models/task.dart';
+
+class TaskService {
+  final String baseUrl;
+
+  TaskService(this.baseUrl);
+
+  Future<List<Task>> fetchTasks() async {
+    final response = await http.get(Uri.parse('$baseUrl/tasks'));
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body) as List<dynamic>;
+      return data.map((e) => Task.fromJson(e as Map<String, dynamic>)).toList();
+    }
+    throw Exception('Failed to fetch tasks');
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,0 +1,22 @@
+name: digi_task
+description: Digi Task mobile client
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^8.1.3
+  http: ^1.2.0
+  equatable: ^2.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:digi_task/main.dart';
+
+void main() {
+  testWidgets('App starts', (tester) async {
+    await tester.pumpWidget(const DigiTaskApp());
+    expect(find.text('Tasks'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- set up basic Laravel backend with Task model and controller
- add Flutter skeleton with Task model and service
- document setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ee9e04d40832280713e72713dab16