### PR TITLE
Add Task API scaffolding

### DIFF
--- a/backend/app/Http/Controllers/TaskController.php
+++ b/backend/app/Http/Controllers/TaskController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Task;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class TaskController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Task::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'user_id' => ['required', 'exists:users,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'due_at' => ['nullable', 'date'],
+        ]);
+
+        $task = Task::create($data);
+
+        return response()->json($task, Response::HTTP_CREATED);
+    }
+
+    public function show(Task $task)
+    {
+        return response()->json($task);
+    }
+
+    public function update(Request $request, Task $task)
+    {
+        $data = $request->validate([
+            'title' => ['sometimes', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'due_at' => ['sometimes', 'nullable', 'date'],
+            'is_completed' => ['sometimes', 'boolean'],
+        ]);
+
+        $task->update($data);
+
+        return response()->json($task);
+    }
+
+    public function destroy(Task $task)
+    {
+        $task->delete();
+
+        return response()->json(status: Response::HTTP_NO_CONTENT);
+    }
+}

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'description',
+        'due_at',
+        'is_completed',
+    ];
+
+    protected $casts = [
+        'is_completed' => 'boolean',
+        'due_at' => 'datetime',
+    ];
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
+        api: __DIR__.'/../routes/api.php',
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',

--- a/backend/database/factories/TaskFactory.php
+++ b/backend/database/factories/TaskFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Task>
+ */
+class TaskFactory extends Factory
+{
+    protected $model = Task::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => $this->faker->sentence,
+            'description' => $this->faker->paragraph,
+            'due_at' => now()->addDay(),
+            'is_completed' => false,
+        ];
+    }
+}

--- a/backend/database/migrations/2025_06_15_170019_create_tasks_table.php
+++ b/backend/database/migrations/2025_06_15_170019_create_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->timestamp('due_at')->nullable();
+            $table->boolean('is_completed')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\TaskController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('tasks', TaskController::class);

--- a/backend/tests/Feature/TaskApiTest.php
+++ b/backend/tests/Feature/TaskApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TaskApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_and_fetch_task(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/tasks', [
+            'user_id' => $user->id,
+            'title' => 'Test Task',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('title', 'Test Task');
+
+        $taskId = $response->json('id');
+
+        $this->getJson("/api/tasks/$taskId")
+            ->assertOk()
+            ->assertJsonPath('id', $taskId);
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic Laravel tasks model, controller, and migration
- register API routes
- add a feature test for tasks
- wire up `api.php` route file in the app bootstrap

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684efb5ba20c8322b275bea6f5871685